### PR TITLE
Update aan layout en fixes

### DIFF
--- a/GDV-Blok2-Tool-NielsV-BobJ-UnityProj/Assets/Editor/LocalizationTool/AddLanguageWizard.cs
+++ b/GDV-Blok2-Tool-NielsV-BobJ-UnityProj/Assets/Editor/LocalizationTool/AddLanguageWizard.cs
@@ -7,20 +7,28 @@ public class AddLanguageWizard : EditorWindow {
 	string languageName;
     static LocalizeWindow tool;
 
+    private static float textFieldSize = 1 * EditorGUIUtility.singleLineHeight;
+    private static float windowHeight = 2.2f * EditorGUIUtility.singleLineHeight;
+    private static float windowWidth = 18 * EditorGUIUtility.singleLineHeight;
+
     public static void Create(LocalizeWindow toolWin) {
         tool = toolWin;
         GetWindow<AddLanguageWizard>("Add Language");
+        GetWindow<AddLanguageWizard>().minSize = new Vector2(windowWidth, windowHeight);
+        GetWindow<AddLanguageWizard>().maxSize = new Vector2(windowWidth, windowHeight);
     }
 
     private static AddLanguageWizard wizard;
    
 
-	void OnGUI(){
+	private void OnGUI(){
         Event e = Event.current;
 
-		languageName = EditorGUILayout.TextField (languageName, GUILayout.Height(position.height - 30));
+        
 
-		if (GUILayout.Button("Add") || (e.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return)){
+		languageName = EditorGUILayout.TextField (languageName, GUILayout.Height(position.height - 30), GUILayout.Height(textFieldSize));
+
+		if (GUILayout.Button("Add") || (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)){
             //LocalizeWindow.data.languages.Add (languageName, new Dictionary<string, string>());
             //         LocalizeWindow.options.Add(languageName);
             LocalizationManager.AddLang(languageName);

--- a/GDV-Blok2-Tool-NielsV-BobJ-UnityProj/Assets/Editor/LocalizationTool/ToolWindow.cs
+++ b/GDV-Blok2-Tool-NielsV-BobJ-UnityProj/Assets/Editor/LocalizationTool/ToolWindow.cs
@@ -111,8 +111,8 @@ public class LocalizeWindow : EditorWindow {
         #endregion
 
         #region Popup
-        Rect popup = new Rect(new Vector2(0, 3 * EditorGUIUtility.singleLineHeight), new Vector2(this.position.width, EditorGUIUtility.singleLineHeight));
-
+        Rect popup = new Rect(new Vector2(this.position.size.x - (2 *standardButtonWidth), 3.2f * EditorGUIUtility.singleLineHeight), new Vector2(2 * standardButtonWidth, EditorGUIUtility.singleLineHeight));
+        
         if (data.languages.Keys.Count > 0)
         {
             List<string> options = new List<string>(data.languages.Keys);
@@ -130,24 +130,28 @@ public class LocalizeWindow : EditorWindow {
         }
         #endregion
 
-        EditorGUILayout.Space();
+        EditorGUILayout.Space(); EditorGUILayout.Space();
 
         #region TextBoxes
         EditorGUILayout.BeginHorizontal();
         { 
             //GUILayout.BeginArea(new Rect(0, 4 * EditorGUIUtility.singleLineHeight, this.position.width, EditorGUIUtility.singleLineHeight * 6));
             EditorGUILayout.BeginVertical();
+            //GUILayout.BeginArea(new Rect(0.0f, minWindowHeight *5, GetWindow<LocalizeWindow>().position.size.x / 2, GetWindow<LocalizeWindow>().position.size.y));
             {
                 EditorGUILayout.LabelField("Original text", EditorStyles.boldLabel);
                 //EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.TextArea(GetTextDebug(data.languages.Keys.FirstOrDefault(), selectedDialog), GUIStyle.none,
+                GUI.skin.label.wordWrap = true;
+                GUILayout.Label("Helo I am Beb and I am a Game Developer right now I'm trying to build a cool looking tool that is kinda easy to use but Unity is being a doodoo and I do not like it.", 
+                    //GUIStyle.none,
                     GUILayout.MinHeight(minTextFieldHeight),
                     GUILayout.MaxHeight(maxTextFieldHeight),
                     GUILayout.MinWidth(minTextFieldWidth),
                     GUILayout.MaxWidth(maxTextFieldWidth)
                     );
                 //EditorGUILayout.EndHorizontal();
-            }EditorGUILayout.EndVertical();
+            }
+            EditorGUILayout.EndVertical();
             //GUILayout.EndArea();
             
 
@@ -241,19 +245,19 @@ public class LocalizeWindow : EditorWindow {
     //    return null;
     //}
 
-    public static string GetTextDebug(string selectedLanguage, string selectedDialog)
-    {
-        Dictionary<string, string> outLang = null;
-        if (selectedLanguage != null && data.languages.TryGetValue(selectedLanguage, out outLang))
-        {
-            string outDialog;
-            if (outLang.TryGetValue(selectedDialog, out outDialog))
-            {
-                return outDialog;
-            }
-        }
-        return null;
-    }
+    //public static string GetTextDebug(string selectedLanguage, string selectedDialog)
+    //{
+    //    Dictionary<string, string> outLang = null;
+    //    if (selectedLanguage != null && data.languages.TryGetValue(selectedLanguage, out outLang))
+    //    {
+    //        string outDialog;
+    //        if (outLang.TryGetValue(selectedDialog, out outDialog))
+    //        {
+    //            return outDialog;
+    //        }
+    //    }
+    //    return null;
+    //}
 
     //public string GetTextDebug(int selectedLanguage, string selectedDialog)
     //{


### PR DESCRIPTION
Add-Language Window
- Enter to confirm werkt nu in één press in plaats van 2 zoals eerder
- Size aangepast zodat het altijd een single-line-height heeft

Languages drop-down
- Is nu smaller zodat het niet de hele breedte van de window inneemt
- Naar rechts geplaatst zodat het nu onder de Add Language button zit
- Iets naar beneden verplaatst zodat het niet meer op de rand van de box erboven zit, alles eronder is hierdoor ook iets naar beneden verplaatst

Original Text subwindow
- Deze is nu een Label, wat betekent dat de gebruiker er niet meer in kan typen
- Source text in Original Text subwindow wrapt nu als regels te lang worden, zoals het hoort, en zodat de window gescaled kan worden zonder problemen